### PR TITLE
Update GitHub webhook and API schema for consistency

### DIFF
--- a/src/swagger/github.yaml
+++ b/src/swagger/github.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   title: github webhook receiver
-  version: 0.2.0
+  version: 0.2.1
 paths:
   /pullrequest:
     post:

--- a/src/swagger/github.yaml
+++ b/src/swagger/github.yaml
@@ -190,7 +190,7 @@ components:
             merged_at:
               type: string
             merged:
-              type: bool
+              type: boolean
             user:
               type: object
               required:

--- a/src/swagger/github.yaml
+++ b/src/swagger/github.yaml
@@ -185,10 +185,13 @@ components:
               type: string
             closed_at:
               type: string
+              nullable: true
             updated_at:
               type: string
+              nullable: true
             merged_at:
               type: string
+              nullable: true
             merged:
               type: boolean
             user:


### PR DESCRIPTION
### Description

This pull request includes the following updates to the GitHub webhook and API schema:

- **Update GitHub webhook version to 0.2.1**: Incremented the OpenAPI specification version, incorporating minor improvements or bug fixes while maintaining backward compatibility.
- **Make GitHub API timestamps nullable**: Added nullable properties to `closed_at`, `updated_at`, and `merged_at` fields in the schema for scenarios where these values might not exist.
- **Update 'merged' field type**: Changed the type of the `merged` field from `bool` to `boolean` to align with OpenAPI specifications and ensure consistency in type conventions.

#### This fix following 400 error when closed_at is null
    {
      "detail": "None is not of type 'string' - 'pull_request.closed_at'",
     "status": 400,
     "title": "Bad Request",
     "type": "about:blank"
    }